### PR TITLE
Update to webconsole 5.0.4 - JSon License Free

### DIFF
--- a/webconsole/pom.xml
+++ b/webconsole/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.webconsole</artifactId>
-      <version>5.0.2</version>
+      <version>5.0.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FELIX-6712

the eclipse foundation IP checks always fail on webconsole because oif the JSOn license.

https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/15063

this should be fixes with this commits:
[cleanup Manifest and JSON - LICENSE (](https://github.com/apache/felix-dev/commit/dd17a96ea9e21fbe000848f96aabcd347f938b11) [#304](https://github.com/apache/felix-dev/pull/304) [)](https://github.com/apache/felix-dev/commit/dd17a96ea9e21fbe000848f96aabcd347f938b11)
[Remove mentioning of JSON license](https://github.com/apache/felix-dev/commit/148fcbae4d2d68cc82290ebbdd38efcacd3e26ec)

Would be great to get a release 5.0.4 to pass the IP check